### PR TITLE
Ambiguity test beindings to expose pool as iterator

### DIFF
--- a/swiftnav/ambiguity_test.pxd
+++ b/swiftnav/ambiguity_test.pxd
@@ -1,0 +1,14 @@
+# Copyright (C) 2014 Swift Navigation Inc.
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+cimport ambiguity_test_c
+
+cdef class AmbiguityTest:
+  cdef ambiguity_test_c.ambiguity_test_t *test
+

--- a/swiftnav/ambiguity_test_c.pxd
+++ b/swiftnav/ambiguity_test_c.pxd
@@ -9,13 +9,26 @@
 
 
 from common cimport *
+cimport memory_pool_c
+cimport sats_management_c
 
 cdef extern from "libswiftnav/ambiguity_test.h":
+
+  ctypedef struct hypothesis_t:
+    s32 N[22]
+    float ll
+
   ctypedef struct residual_mtxs_t:
     u32 res_dim
     u8 null_space_dim
     double *null_projector
     double *half_res_cov_inv
+
+  ctypedef struct ambiguity_test_t:
+    u8 num_dds
+    memory_pool_c.memory_pool_t *pool
+    sats_management_c.sats_management_t sats
+    residual_mtxs_t res_mtxs
 
   void assign_phase_obs_null_basis(u8 num_dds, double *DE_mtx, double *q)
   void assign_residual_covariance_inverse(u8 num_dds, double *obs_cov, double *q, double *r_cov_inv)

--- a/swiftnav/ambiguity_test_c.pxd
+++ b/swiftnav/ambiguity_test_c.pxd
@@ -11,11 +11,12 @@
 from common cimport *
 cimport memory_pool_c
 cimport sats_management_c
+from constants_c cimport MAX_CHANNELS
 
 cdef extern from "libswiftnav/ambiguity_test.h":
 
   ctypedef struct hypothesis_t:
-    s32 N[22]
+    s32 N[MAX_CHANNELS-1]
     float ll
 
   ctypedef struct residual_mtxs_t:

--- a/swiftnav/constants_c.pxd
+++ b/swiftnav/constants_c.pxd
@@ -1,0 +1,17 @@
+# Copyright (C) 2014 Swift Navigation Inc.
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+from common cimport *
+
+cdef extern from "libswiftnav/constants.h":
+  # HACK: This is declared as an enum so that Cython knows its a constant
+  # https://groups.google.com/d/msg/cython-users/-fLG08E5lYM/xC93UHSvLF0J
+  enum: MAX_CHANNELS
+

--- a/swiftnav/dgnss_management.pyx
+++ b/swiftnav/dgnss_management.pyx
@@ -23,6 +23,9 @@ from gpstime_c cimport *
 from libc.string cimport memcpy
 from libc.stdio cimport printf
 from sats_management_c cimport *
+from ambiguity_test_c cimport *
+from ambiguity_test import AmbiguityTest
+from ambiguity_test cimport AmbiguityTest
 
 
 def set_settings(phase_var_test, code_var_test,
@@ -528,3 +531,9 @@ def dgnss_iar_MLE_ambs():
     np.empty(32, dtype=np.int32)
   num_dds = dgnss_management_c.dgnss_iar_MLE_ambs(&ambs[0])
   return ambs[:num_dds]
+
+def get_ambiguity_test():
+  test = AmbiguityTest()
+  test.test = dgnss_management_c.get_ambiguity_test()
+  return test
+

--- a/swiftnav/dgnss_management_c.pxd
+++ b/swiftnav/dgnss_management_c.pxd
@@ -11,6 +11,7 @@ from common cimport *
 from single_diff_c cimport *
 from amb_kf_c cimport *
 from sats_management_c cimport *
+cimport ambiguity_test_c
 
 cdef extern from "libswiftnav/dgnss_management.h":
   void dgnss_set_settings(double phase_var_test, double code_var_test,
@@ -52,3 +53,4 @@ cdef extern from "libswiftnav/dgnss_management.h":
   u8 get_amb_kf_prns(u8 *prns)
   u8 get_amb_test_prns(u8 *prns)
   u8 dgnss_iar_MLE_ambs(s32 *ambs)
+  ambiguity_test_c.ambiguity_test_t* get_ambiguity_test()

--- a/swiftnav/memory_pool_c.pxd
+++ b/swiftnav/memory_pool_c.pxd
@@ -1,0 +1,25 @@
+# Copyright (C) 2015 Swift Navigation Inc.
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from common cimport *
+
+cdef extern from "libswiftnav/memory_pool.h":
+
+  ctypedef u8 element_t
+
+  ctypedef struct memory_pool_node_hdr_t:
+    node_t *next
+
+  ctypedef struct node_t:
+    memory_pool_node_hdr_t hdr
+    element_t elem[0]
+
+  ctypedef struct memory_pool_t:
+    node_t *allocated_nodes_head
+


### PR DESCRIPTION
**Why:** We currently don't have any way to inspect the state of the ambiguity test directly from Python. Instead we have a bunch of custom functions in C with corresponding bindings that inspect specific bits of state. It would be much more flexible and faster to develop if we could directly inspect the memory pool in Python.

**How:** Write Cython bindings for the memory pool / ambiguity test that exposes the hypothesis pool as an iterator to be used in python. The hypothesis will be represented as a suitable python type. The implementation will be specialised on the hypothesis pool and will not try to deal with the polymorphism issues around wrapping a general memory pool.

**Testing:** Test by usage in SITL suite. Would be really nice to unit test but the lack of full / flexible bindings to other parts of libswiftnav makes mocking out the test state difficult and so will not be attempted for now.

**Usage details:**

Can now call `get_ambiguity_test()` from `dgnss_management` to get an `AmbiguityTest` class which wraps an `ambiguity_test_t`. The `AmbiguityTest` class exposes the underlying memory pool as an iterator. The iterator runs over the hypothesis pool contents returning `hypothesis_t`s represented as a tuple `(ll, [N])`.

/cc @mookerji @henryhallam @imh 